### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,7 @@ Integracja dla Home Assistant umożliwiająca śledzenie aktualnych cen energii 
 
 ### Metoda 2: Ręczna instalacja
 1. Utwórz folder `custom_components/pstryk` w katalogu konfiguracyjnym HA
-2. Skopiuj pliki:
-init.py
-manifest.json
-config_flow.py
-const.py
-sensor.py
-logo.png (opcjonalnie)
+2. Wgraj wszystkie pliki z repozytorium.
 3. Zrestartuj Home Assistant
 
 ## Konfiguracja


### PR DESCRIPTION
Poprawka instrukcji readme.md dot. manualnej instalacji.

Przed:
`Config flow could not be loaded: {"message":"Invalid handler specified"}.`

Wpis w logach:
`Error occurred loading flow for integration pstryk: No module named 'custom_components.pstryk.mqtt_publisher'`

Po:
Problem znika dopiero po wgraniu wszystkich plików z repo, readme manualna instalacja